### PR TITLE
More generic hessian correction allows for different RT models

### DIFF
--- a/kafka/inference/broadbandSAIL_tools.py
+++ b/kafka/inference/broadbandSAIL_tools.py
@@ -1,0 +1,97 @@
+import logging
+import gdal
+import numpy as np
+import os
+
+from .utils import block_diag
+from .kf_tools import propagate_single_parameter
+
+
+def tip_prior_values():
+    """The JRC-TIP prior in a convenient function which is fun for the whole
+    family. Note that the effective LAI is here defined in transformed space
+    where TLAI = exp(-0.5*LAIe).
+
+    Returns
+    -------
+    The mean prior vector, covariance and inverse covariance matrices."""
+    # broadly TLAI 0->7 for 1sigma
+    sigma = np.array([0.12, 0.7, 0.0959, 0.15, 1.5, 0.2, 0.5])
+    x0 = np.array([0.17, 1.0, 0.1, 0.7, 2.0, 0.18, np.exp(-0.5*1.5)])
+    # The individual covariance matrix
+    little_p = np.diag(sigma**2).astype(np.float32)
+    little_p[5, 2] = 0.8862*0.0959*0.2
+    little_p[2, 5] = 0.8862*0.0959*0.2
+
+    inv_p = np.linalg.inv(little_p)
+    return x0, little_p, inv_p
+
+
+class JRCPrior(object):
+    """Dummpy 2.7/3.6 prior class following the same interface as 3.6 only
+    version."""
+
+    def __init__(self, parameter_list, state_mask):
+        """It makes sense to have the list of parameters and state mask
+        defined at this point, as they won't change during processing."""
+        self.mean, self.covar, self.inv_covar = self._tip_prior()
+        self.parameter_list = parameter_list
+        if isinstance(state_mask, (np.ndarray, np.generic) ):
+            self.state_mask = state_mask
+        else:
+            self.state_mask = self._read_mask(state_mask)
+
+    def _read_mask(self, fname):
+        """Tries to read the mask as a GDAL dataset"""
+        if not os.path.exists(fname):
+            raise IOError("State mask is neither an array or a file that exists!")
+        g = gdal.Open(fname)
+        if g is None:
+            raise IOError("{:s} can't be opened with GDAL!".format(fname))
+        mask = g.ReadAsArray()
+        return mask
+
+    def _tip_prior(self):
+        """The JRC-TIP prior in a convenient function which is fun for the whole
+        family. Note that the effective LAI is here defined in transformed space
+        where TLAI = exp(-0.5*LAIe).
+
+        Returns
+        -------
+        The mean prior vector, covariance and inverse covariance matrices."""
+        mean, c_prior, c_inv_prior = tip_prior_values()
+        self.mean = mean
+        self.covar = c_prior
+        self.inv_covar = c_inv_prior
+        return mean, c_prior, c_inv_prior
+
+    def process_prior ( self, time, inv_cov=True):
+        # Presumably, self._inference_prior has some method to retrieve
+        # a bunch of files for a given date...
+        n_pixels = self.state_mask.sum()
+        x0 = np.array([self.mean for i in range(n_pixels)]).flatten()
+        if inv_cov:
+            inv_covar_list = [self.inv_covar for m in range(n_pixels)]
+            inv_covar = block_diag(inv_covar_list, dtype=np.float32)
+            return x0, inv_covar
+        else:
+            covar_list = [self.covar for m in range(n_pixels)]
+            covar = block_diag(covar_list, dtype=np.float32)
+            return x0, covar
+
+
+def propagate_LAI_broadbandSAIL(x_analysis, P_analysis,
+                                     P_analysis_inverse,
+                                     M_matrix, Q_matrix,
+                                     prior=None, state_propagator=None, date=None):
+    """Propagate a single parameter and
+      set the rest of the parameter propagations to the prior.
+      This should be used with a prior for the remaining parameters"""
+    nparameters = 7
+    lai_position = 6
+    x_prior, c_prior, c_inv_prior = tip_prior_values()
+    return propagate_single_parameter(x_analysis, P_analysis,
+                                      P_analysis_inverse,
+                                      M_matrix, Q_matrix,
+                                      nparameters, lai_position,
+                                      x_prior, c_inv_prior)

--- a/kafka/inference/narrowbandSAIL_tools.py
+++ b/kafka/inference/narrowbandSAIL_tools.py
@@ -1,0 +1,103 @@
+import logging
+import numpy as np
+from .utils import block_diag
+import os
+import gdal
+
+def sail_prior_values():
+    """
+    :returns
+    -------
+    The mean prior vector, covariance and inverse covariance matrices."""
+
+    mean = np.array([2.1, np.exp(-60. / 100.),
+                     np.exp(-7.0 / 100.), 0.1,
+                     np.exp(-50 * 0.0176), np.exp(-100. * 0.002),
+                     np.exp(-4. / 2.), 70. / 90., 0.5, 0.9])
+    sigma = np.array([0.01, 0.2,
+                              0.01, 0.05,
+                              0.01, 0.01,
+                              0.50, 0.1, 0.1, 0.1])
+
+    covar = np.diag(sigma ** 2).astype(np.float32)
+    inv_covar = np.diag(1. / sigma ** 2).astype(np.float32)
+    return mean, covar, inv_covar
+
+class SAILPrior(object):
+    def __init__(self, parameter_list, state_mask):
+        self.parameter_list = parameter_list
+        if isinstance(state_mask, (np.ndarray, np.generic)):
+            self.state_mask = state_mask
+        else:
+            self.state_mask = self._read_mask(state_mask)
+            # parameter_list = ['n', 'cab', 'car', 'cbrown', 'cw', 'cm',
+            #                 'lai', 'ala', 'bsoil', 'psoil']
+            # self.mean = np.array([1.19, np.exp(-14.4/100.),
+            # np.exp(-4.0/100.), 0.1,
+            # np.exp(-50*0.68), np.exp(-100./21.0),
+            # np.exp(-3.97/2.),70./90., 0.5, 0.9])
+            # sigma = np.array([0.69, 0.016,
+            # 0.0086, 0.1,
+            # 1.71e-2, 0.017,
+            # 0.20, 0.5, 0.5, 0.5])
+            mean, c_prior, c_inv_prior = sail_prior_values()
+            self.mean = mean
+            self.covar = c_prior
+            self.inv_covar = c_inv_prior
+
+
+    def _read_mask(self, fname):
+        """Tries to read the mask as a GDAL dataset"""
+        if not os.path.exists(fname):
+            raise IOError("State mask is neither an array or a file that exists!")
+        g = gdal.Open(fname)
+        if g is None:
+            raise IOError("{:s} can't be opened with GDAL!".format(fname))
+        mask = g.ReadAsArray()
+        return mask
+
+    def process_prior ( self, time, inv_cov=True):
+        # Presumably, self._inference_prior has some method to retrieve
+        # a bunch of files for a given date...
+        n_pixels = self.state_mask.sum()
+        x0 = np.array([self.mean for i in range(n_pixels)]).flatten()
+        if inv_cov:
+            inv_covar_list = [self.inv_covar for m in range(n_pixels)]
+            inv_covar = block_diag(inv_covar_list, dtype=np.float32)
+            return x0, inv_covar
+        else:
+            covar_list = [self.covar for m in range(n_pixels)]
+            covar = block_diag(covar_list, dtype=np.float32)
+            return x0, covar
+
+
+
+
+def propagate_LAI_narrowbandSAIL(x_analysis, P_analysis,
+                                     P_analysis_inverse,
+                                     M_matrix, Q_matrix,
+                                     prior=None, state_propagator=None, date=None):
+    ''' Propagate a single parameter and
+     set the rest of the parameter propagations to zero
+     This should be used with a prior for the remaining parameters'''
+    nparameters = 10
+    lai_position = 6
+
+    x_prior, c_prior, c_inv_prior = sail_prior_values()
+
+    x_forecast = M_matrix.dot(x_analysis)
+    n_pixels = len(x_analysis)//nparameters
+    x0 = np.tile(x_prior, n_pixels)
+    x0[lai_position::nparameters] = x_forecast[lai_position::nparameters] # Update LAI
+    lai_post_cov = P_analysis_inverse.diagonal()[lai_position::nparameters]
+    lai_Q = Q_matrix.diagonal()[lai_position::nparameters]
+
+    c_inv_prior_mat = []
+    for cov, Q in zip(lai_post_cov, lai_Q):
+        # inflate uncertainty
+        lai_inv_cov = 1.0/((1.0/cov)+Q)
+        little_P_forecast_inverse = c_inv_prior.copy()
+        little_P_forecast_inverse[lai_position, lai_position] = lai_inv_cov
+        c_inv_prior_mat.append(little_P_forecast_inverse)
+    P_forecast_inverse=block_diag(c_inv_prior_mat, dtype=np.float32)
+    return x0, None, P_forecast_inverse

--- a/kafka/inference/utils.py
+++ b/kafka/inference/utils.py
@@ -228,7 +228,15 @@ def create_prosail_observation_operator(n_params, emulator, metadata,
     LOG.info("\tDone!")
 
     if calc_hess:
-        hess = emulator.hessian(x0[mask[state_mask]])
+        hess = np.zeros((n_times, n_params, n_params),
+                             dtype=np.float32)
+        hess_ = emulator.hessian(x0[mask[state_mask]])
+
+        n = 0
+        for i, m in enumerate(mask[state_mask].flatten()):
+            if m:
+                hess[i, ...] = hess_[n]
+                n += 1
 
     return (H0, H_matrix.tocsr(), hess) if calc_hess else (H0, H_matrix.tocsr())
 
@@ -357,7 +365,7 @@ def spsolve2(a, b):
     a_lu = spl.splu(a.tocsc())   # LU decomposition for sparse a
     out = sp.lil_matrix((a.shape[1], b.shape[1]), dtype=np.float32)
     b_csc = b.tocsc()
-    for j in xrange(b.shape[1]):
+    for j in range(b.shape[1]):
         bb = np.array(b_csc[j, :].todense()).squeeze()
         out[j, j] = a_lu.solve(bb)[j]
     return out.tocsr()

--- a/kafka/inference/utils.py
+++ b/kafka/inference/utils.py
@@ -125,7 +125,8 @@ def create_linear_observation_operator(obs_op, n_params, metadata,
 
 
 def create_nonlinear_observation_operator(n_params, emulator, metadata,
-                                          mask, state_mask,  x_forecast, band):
+                                          mask, state_mask,  x_forecast,
+                                          band, calc_hess=False):
     """Using an emulator of the nonlinear model around `x_forecast`.
     This case is quite special, as I'm focusing on a BHR SAIL
     version (or the JRC TIP), which have spectral parameters
@@ -171,18 +172,17 @@ def create_nonlinear_observation_operator(n_params, emulator, metadata,
 
     LOG.info("\tDone!")
 
-    '''if calc_hess:
+    if calc_hess:
         ddH = emulator.hessian(x0[mask[state_mask]])
-        hess = np.zeros((n_times, nparams, nparams))
-        for lil_hes , m in zip(ddH, mask[state_mask].flatten()):
+        hess = np.zeros((n_times, n_params, n_params))
+        for n, (lil_hess, m) in enumerate(zip(ddH, mask[state_mask].flatten())):
             if m:
-                big_ddH = np.zeros((nparams, nparams))
+                big_hess = np.zeros((n_params, n_params))
                 for i, ii in enumerate(state_mapper):
                     for j, jj in enumerate(state_mapper):
-                        #big_ddH[ii, jj] = .squeeze()[i, j]
-                        pass
-            #hess[.append(big_ddH)
-    '''
+                        big_hess[ii, jj] = lil_hess.squeeze()[i, j]
+                hess[n,...] = big_hess
+
     return (H0, H_matrix.tocsr(), hess) if calc_hess else (H0, H_matrix.tocsr())
 
 

--- a/kafka/inference/utils.py
+++ b/kafka/inference/utils.py
@@ -171,12 +171,26 @@ def create_nonlinear_observation_operator(n_params, emulator, metadata,
 
     LOG.info("\tDone!")
 
-    return (H0, H_matrix.tocsr())
+    '''if calc_hess:
+        ddH = emulator.hessian(x0[mask[state_mask]])
+        hess = np.zeros((n_times, nparams, nparams))
+        for lil_hes , m in zip(ddH, mask[state_mask].flatten()):
+            if m:
+                big_ddH = np.zeros((nparams, nparams))
+                for i, ii in enumerate(state_mapper):
+                    for j, jj in enumerate(state_mapper):
+                        #big_ddH[ii, jj] = .squeeze()[i, j]
+                        pass
+            #hess[.append(big_ddH)
+    '''
+    return (H0, H_matrix.tocsr(), hess) if calc_hess else (H0, H_matrix.tocsr())
+
 
 
 
 def create_prosail_observation_operator(n_params, emulator, metadata,
-                                          mask, state_mask,  x_forecast, band):
+                                          mask, state_mask,  x_forecast,
+                                          band, calc_hess=False):
     """Using an emulator of the nonlinear model around `x_forecast`.
     This case is quite special, as I'm focusing on a BHR SAIL
     version (or the JRC TIP), which have spectral parameters
@@ -213,7 +227,10 @@ def create_prosail_observation_operator(n_params, emulator, metadata,
 
     LOG.info("\tDone!")
 
-    return (H0, H_matrix.tocsr())
+    if calc_hess:
+        hess = emulator.hessian(x0[mask[state_mask]])
+
+    return (H0, H_matrix.tocsr(), hess) if calc_hess else (H0, H_matrix.tocsr())
 
 
 

--- a/kafka/linear_kf.py
+++ b/kafka/linear_kf.py
@@ -183,8 +183,8 @@ class LinearKalman (object):
                 x_forecast, P_forecast, P_forecast_inverse = self.advance(
                     x_analysis, P_analysis, P_analysis_inverse,
                     self.trajectory_model, self.trajectory_uncertainty)
-
             is_first = False
+
             if len(locate_times) == 0:
                 # Just advance the time
                 x_analysis = x_forecast
@@ -256,14 +256,22 @@ class LinearKalman (object):
                 # Also extract single band information from nice package
                 # this allows us to use the same interface as current
                 # Deferring processing to a new solver method in solvers.py
-                
-                H_matrix_= self._create_observation_operator(self.n_params,
+
+                try:
+                    H_matrix_= self._create_observation_operator(self.n_params,
                                                          data.emulator,
                                                          data.metadata,
                                                          data.mask,
                                                          self.state_mask,
                                                          x_prev,
-                                                         band)
+                                                         band,
+                                                         calc_hess = False)
+                except ValueError as e:
+                    if (sum(data.mask[self.state_mask])== 0):
+                        LOG.error("All observations masked out")
+                    raise
+
+
                 H_matrix.append(H_matrix_)
                 Y.append(data.observations)
                 MASK.append(data.mask)

--- a/kafka/linear_kf.py
+++ b/kafka/linear_kf.py
@@ -37,7 +37,6 @@ from .inference import locate_in_lut, run_emulator, create_uncertainty
 from .inference import create_linear_observation_operator
 from .inference import create_nonlinear_observation_operator
 from .inference import iterate_time_grid
-from .inference import propagate_information_filter_LAI # eg
 from .inference import hessian_correction
 from .inference import hessian_correction_multiband
 from .inference.kf_tools import propagate_and_blend_prior
@@ -64,7 +63,7 @@ class LinearKalman (object):
     rather grotty "0-th" order models!"""
     def __init__(self, observations, output, state_mask,
                  create_observation_operator, parameters_list,
-                 state_propagation=propagate_information_filter_LAI,
+                 state_propagation=None,
                  linear=True, diagnostics=True, prior=None):
         """The class creator takes (i) an observations object, (ii) an output
         writer object, (iii) the state mask (a boolean 2D array indicating which

--- a/kafka/linear_kf.py
+++ b/kafka/linear_kf.py
@@ -426,7 +426,13 @@ class LinearKalman (object):
         P_analysis_inverse = P_analysis_inverse - P_correction
         # Rarely, this returns a small negative value. For now set to nan.
         # May require further investigation in the future
-        P_analysis_inverse[P_analysis_inverse<0] = np.nan
+        negative_values = P_analysis_inverse<0
+        if any(negative_values):
+            P_analysis_inverse[negative_values] = np.nan
+            LOG.warning("{} negative values in inverse covariance matrix".format(
+                sum(negative_values)))
+
+
         import matplotlib.pyplot as plt
         M = self.state_mask*1.
         M[self.state_mask] = x_analysis[6::7]

--- a/kafka_test_Py36.py
+++ b/kafka_test_Py36.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 import logging
-logging.basicConfig( 
-    level=logging.getLevelName(logging.DEBUG), 
+logging.basicConfig(
+    level=logging.getLevelName(logging.DEBUG),
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     filename="the_log.log")
 import os
@@ -11,7 +11,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import gdal
 import osr
-import scipy.sparse as sp
 
 # from multiply.inference-engine blah blah blah
 try:
@@ -19,17 +18,16 @@ try:
 except ImportError:
     pass
 
-import kafka
 from kafka.input_output import BHRObservations, KafkaOutput
 from kafka import LinearKalman
-from kafka.inference import block_diag
-from kafka.inference import propagate_information_filter_LAI
-from kafka.inference import no_propagation
+from kafka.inference.broadbandSAIL_tools import propagate_LAI_broadbandSAIL
 from kafka.inference import create_nonlinear_observation_operator
+from kafka.inference.broadbandSAIL_tools import JRCPrior
 
 
 # Probably should be imported from somewhere else, but I can't see
 # where from ATM... No biggy
+
 
 def reproject_image(source_img, target_img, dstSRSs=None):
     """Reprojects/Warps an image to fit exactly another image.
@@ -54,73 +52,6 @@ def reproject_image(source_img, target_img, dstSRSs=None):
                   dstSRS=dstSRS)
     return g
 
-
-
-###class DummyInferencePrior(_WrappingInferencePrior):
-    ###"""
-    ###This class is merely a dummy.
-    ###"""
-
-    ###def process_prior(self, parameters: List[str], time: Union[str, datetime], state_grid: np.array,
-
-
-class JRCPrior(object):
-    """Dummpy 2.7/3.6 prior class following the same interface as 3.6 only
-    version."""
-
-    def __init__ (self, parameter_list, state_mask):
-        """It makes sense to have the list of parameters and state mask
-        defined at this point, as they won't change during processing."""
-        self.mean, self.covar, self.inv_covar = self._tip_prior() 
-        self.parameter_list = parameter_list
-        if isinstance(state_mask, (np.ndarray, np.generic) ):
-            self.state_mask = state_mask
-        else:
-            self.state_mask = self._read_mask(state_mask)
-            
-    def _read_mask(self, fname):
-        """Tries to read the mask as a GDAL dataset"""
-        if not os.path.exists(fname):
-            raise IOError("State mask is neither an array or a file that exists!")
-        g = gdal.Open(fname)
-        if g is None:
-            raise IOError("{:s} can't be opened with GDAL!".format(fname))
-        mask = g.ReadAsArray()
-        return mask
-
-    def _tip_prior(self):
-        """The JRC-TIP prior in a convenient function which is fun for the whole
-        family. Note that the effective LAI is here defined in transformed space
-        where TLAI = exp(-0.5*LAIe).
-
-        Returns
-        -------
-        The mean prior vector, covariance and inverse covariance matrices."""
-        # broadly TLAI 0->7 for 1sigma
-        sigma = np.array([0.12, 0.7, 0.0959, 0.15, 1.5, 0.2, 0.5])
-        x0 = np.array([0.17, 1.0, 0.1, 0.7, 2.0, 0.18, np.exp(-0.5*2.)])
-        # The individual covariance matrix
-        little_p = np.diag(sigma**2).astype(np.float32)
-        little_p[5, 2] = 0.8862*0.0959*0.2
-        little_p[2, 5] = 0.8862*0.0959*0.2
-
-        inv_p = np.linalg.inv(little_p)
-        return x0, little_p, inv_p
-
-    def process_prior ( self, time, inv_cov=True):
-        # Presumably, self._inference_prior has some method to retrieve 
-        # a bunch of files for a given date...
-        n_pixels = self.state_mask.sum()
-        x0 = np.array([self.mean for i in range(n_pixels)]).flatten()
-        if inv_cov:
-            inv_covar_list = [self.inv_covar for m in range(n_pixels)]
-            inv_covar = block_diag(inv_covar_list, dtype=np.float32)
-            return x0, inv_covar
-        else:
-            covar_list = [self.covar for m in xrange(n_pixels)]
-            covar = block_diag(covar_list, dtype=np.float32)
-            return x0, covar
-        
 class KafkaOutputMemory(object):
     """A very simple class to output the state."""
     def __init__(self, parameter_list):
@@ -134,57 +65,91 @@ class KafkaOutputMemory(object):
         self.output[timestep] = solution
 
 
-if __name__ == "__main__":
-    
-    parameter_list = ["w_vis", "x_vis", "a_vis",
-                     "w_nir", "x_nir", "a_nir", "TeLAI"]
-    
-    tile = "h11v04"
-    start_time = "2006185"
-    
-    emulator = "./SAIL_emulator_both_500trainingsamples.pkl"
-    
-    if os.path.exists("/storage/ucfajlg/Ujia/MCD43/"):
-        mcd43a1_dir = "/storage/ucfajlg/Ujia/MCD43/"
-    else:
-        mcd43a1_dir="/data/MODIS/h11v04/MCD43"
-    ####tilewidth = 75
-    ###n_pixels = tilewidth*tilewidth
-    mask = np.zeros((2400,2400),dtype=np.bool8)
-    #mask[900:940, 1300:1340] = True # Alcornocales
-    #mask[640:700, 1400:1500] = True # Campinha
-    #mask[650:730, 1180:1280] = True # Arros
-    mask[ 2200:2395, 450:700 ] = True # Bondville, h11v04
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
 
-    bhr_data =  BHRObservations(emulator, tile, mcd43a1_dir, start_time,
-                                end_time=None, mcd43a2_dir=None)
+
+if __name__ == "__main__":
+
+    # Set up logging
+    Log = logging.getLogger(__name__+".kafka_test_x.py")
+
+    runname = 'Arros_0-25'  #Used in output directory as a unique identifier
+    propagator = propagate_LAI_broadbandSAIL
+    parameter_list = ["w_vis", "x_vis", "a_vis",
+                      "w_nir", "x_nir", "a_nir", "TeLAI"]
+
+    ## parameters for Bondville data.
+    #tile = "h11v04"      # Bondville
+    #start_time = "2006001"    # Bondville
+    #cd43a1_dir="/data/MODIS/h11v04/MCD43"
+    ## Bondville chip
+    #masklim = ((2200, 2450), (450, 700))   # Bondville, h11v04
+
+    # Parameters for Spanish tile
+    tile = "h17v05"      # Spain
+    start_time = "2017001"    # Spain
+    mcd43a1_dir="/data/MODIS/h17v05/MCD43"
+    # chips in h17v05 Spain, select one
+    masklim = ((650, 730), (1180, 1280))     # Arros, rice
+    #masklim = ((900,940), (1300,1340)) = True # Alcornocales
+    #masklim = ((640,700), (1400,1500)) = True # Campinha
+
+
+
+    path = "/home/npounder/output/kafka/28Mar/kafkaout_{}".format(runname)
+    if not os.path.exists(path):
+        mkdir_p(path)
+
+    emulator = "./SAIL_emulator_both_500trainingsamples.pkl"
+
+
+    mask = np.zeros((2400,2400),dtype=np.bool8)
+    mask[masklim[0][0]:masklim[0][1],
+         masklim[1][0]:masklim[1][1]] = True
+
+    bhr_data = BHRObservations(emulator, tile, mcd43a1_dir, start_time,
+                               end_time=None, mcd43a2_dir=None, period=8)
+
+    Log.info("runname = {}".format(runname))
+    Log.info("propagator = {}".format(propagator))
+    Log.info("tile = {}".format(tile))
+    Log.info("start_time = {}".format(start_time))
+    Log.info("mask = {}".format(masklim))
 
     projection, geotransform = bhr_data.define_output()
 
-    output = KafkaOutput(parameter_list, geotransform, projection, "/tmp/")
+    output = KafkaOutput(parameter_list, geotransform, projection, path)
 
     the_prior = JRCPrior(parameter_list, mask)
-    
-    kf = LinearKalman(bhr_data, output, mask, 
+
+    # prior = None when using propagate_LAI_broadbandSAIL
+    kf = LinearKalman(bhr_data, output, mask,
                       create_nonlinear_observation_operator,parameter_list,
-                      state_propagation=None,
-                      prior=the_prior,
+                      state_propagation=propagator,
+                      prior=None,
                       linear=False)
 
     # Get starting state... We can request the prior object for this
     x_forecast, P_forecast_inv = the_prior.process_prior(None)
-    
+
     Q = np.zeros_like(x_forecast)
-    Q[6::7] = 0.025
-    
+    Q[6::7] = 0.25
+
     kf.set_trajectory_model()
     kf.set_trajectory_uncertainty(Q)
-    
-    base = datetime(2006,7,4)
-    num_days = 180
+
+    # This determines the time grid of the retrieved state parameters
+    base = datetime(2017, 1, 1)
+    num_days = 366
     time_grid = []
-    for x in range( 0, num_days, 16):
-        time_grid.append( base + timedelta(days = x) )
+    for x in range( 0, num_days, 8):
+        time_grid.append(base + timedelta(days=x))
 
     kf.run(time_grid, x_forecast, None, P_forecast_inv, iter_obs_op=True)
-    

--- a/kafka_test_Py36.py
+++ b/kafka_test_Py36.py
@@ -81,6 +81,11 @@ if __name__ == "__main__":
     Log = logging.getLogger(__name__+".kafka_test_x.py")
 
     runname = 'Arros_0-25'  #Used in output directory as a unique identifier
+    # To run without propagation set propagator to None and set a
+    # prior in LinearKalman.
+    # If propagator is set to propagate_LAI_broadbandSAIL then the
+    # prior in LinearKalman must be set to None because this propagator
+    # includes a prior
     propagator = propagate_LAI_broadbandSAIL
     parameter_list = ["w_vis", "x_vis", "a_vis",
                       "w_nir", "x_nir", "a_nir", "TeLAI"]
@@ -127,6 +132,8 @@ if __name__ == "__main__":
 
     output = KafkaOutput(parameter_list, geotransform, projection, path)
 
+    # If using a separate prior then this is passed to LinearKalman
+    # Otherwise this is just used to set the starting state vector.
     the_prior = JRCPrior(parameter_list, mask)
 
     # prior = None when using propagate_LAI_broadbandSAIL

--- a/kafka_test_Py36.py
+++ b/kafka_test_Py36.py
@@ -81,6 +81,7 @@ if __name__ == "__main__":
     Log = logging.getLogger(__name__+".kafka_test_x.py")
 
     runname = 'Arros_0-25'  #Used in output directory as a unique identifier
+
     # To run without propagation set propagator to None and set a
     # prior in LinearKalman.
     # If propagator is set to propagate_LAI_broadbandSAIL then the
@@ -108,7 +109,7 @@ if __name__ == "__main__":
 
 
 
-    path = "/home/npounder/output/kafka/28Mar/kafkaout_{}".format(runname)
+    path = "/tmp/kafkaout_{}".format(runname)
     if not os.path.exists(path):
         mkdir_p(path)
 
@@ -122,7 +123,6 @@ if __name__ == "__main__":
     bhr_data = BHRObservations(emulator, tile, mcd43a1_dir, start_time,
                                end_time=None, mcd43a2_dir=None, period=8)
 
-    Log.info("runname = {}".format(runname))
     Log.info("propagator = {}".format(propagator))
     Log.info("tile = {}".format(tile))
     Log.info("start_time = {}".format(start_time))

--- a/kafka_test_S2.py
+++ b/kafka_test_S2.py
@@ -4,7 +4,7 @@ import logging
 logging.basicConfig( 
     level=logging.getLevelName(logging.DEBUG), 
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    filename="the_log.log")
+    filename="Campinha_noprop_2017.log")
 import os
 from datetime import datetime, timedelta
 import numpy as np
@@ -28,13 +28,12 @@ except ImportError:
 import kafka
 from kafka.input_output import Sentinel2Observations, KafkaOutput
 from kafka import LinearKalman
-from kafka.inference import block_diag
-from kafka.inference import propagate_information_filter_LAI
-from kafka.inference import no_propagation
+from kafka.inference.narrowbandSAIL_tools import propagate_LAI_narrowbandSAIL
 from kafka.inference import create_prosail_observation_operator
-
+from kafka.inference.narrowbandSAIL_tools import SAILPrior
 # Probably should be imported from somewhere else, but I can't see
 # where from ATM... No biggy
+
 
 def reproject_image(source_img, target_img, dstSRSs=None):
     """Reprojects/Warps an image to fit exactly another image.
@@ -59,82 +58,6 @@ def reproject_image(source_img, target_img, dstSRSs=None):
                   dstSRS=dstSRS)
     return g
 
-
-
-###class DummyInferencePrior(_WrappingInferencePrior):
-    ###"""
-    ###This class is merely a dummy.
-    ###"""
-
-    ###def process_prior(self, parameters: List[str], time: Union[str, datetime], state_grid: np.array,
-
-class SAILPrior(object):
-    def __init__ (self, parameter_list, state_mask):
-        self.parameter_list = parameter_list
-        if isinstance(state_mask, (np.ndarray, np.generic) ):
-            self.state_mask = state_mask
-        else:
-            self.state_mask = self._read_mask(state_mask)
-    #parameter_list = ['n', 'cab', 'car', 'cbrown', 'cw', 'cm',
-     #                 'lai', 'ala', 'bsoil', 'psoil']
-            #self.mean = np.array([1.19, np.exp(-14.4/100.),
-                                 #np.exp(-4.0/100.), 0.1,
-                                 #np.exp(-50*0.68), np.exp(-100./21.0),
-                                 #np.exp(-3.97/2.),70./90., 0.5, 0.9])
-            #sigma = np.array([0.69, 0.016,
-                                 #0.0086, 0.1,
-                                 #1.71e-2, 0.017,
-                                 #0.20, 0.5, 0.5, 0.5])
-            self.mean = np.array([2.1, np.exp(-60./100.),
-                                 np.exp(-7.0/100.), 0.1,
-                                 np.exp(-50*0.0176), np.exp(-100.*0.002),
-                                 np.exp(-4./2.), 70./90., 0.5, 0.9])
-            sigma = np.array([0.01, 0.2,
-                                 0.01, 0.05,
-                                 0.01, 0.01,
-                                 0.50, 0.1, 0.1, 0.1])
- 
-            self.covar = np.diag(sigma**2).astype(np.float32)
-            self.inv_covar = np.diag(1./sigma**2).astype(np.float32)
-            #self.inv_covar[3,3]=0
-        ########self.mean = 
-        ########self.variance = 
-    ########lai_m2_m2: [3.1733 1.7940]
-
-    ########cab_ug_cm2: [14.4369 1.8284]
-
-     ########car_u_cm2: [3.9650 0.8948]
-
-     ########cdm_g_cm2: [20.9675 6.4302]
-
-         ########cw_cm: [0.6781 0.6749]
-
-            ########N_: [1.1937 0.6902]    
-        
-    def _read_mask(self, fname):
-        """Tries to read the mask as a GDAL dataset"""
-        if not os.path.exists(fname):
-            raise IOError("State mask is neither an array or a file that exists!")
-        g = gdal.Open(fname)
-        if g is None:
-            raise IOError("{:s} can't be opened with GDAL!".format(fname))
-        mask = g.ReadAsArray()
-        return mask
-
-    def process_prior ( self, time, inv_cov=True):
-        # Presumably, self._inference_prior has some method to retrieve 
-        # a bunch of files for a given date...
-        n_pixels = self.state_mask.sum()
-        x0 = np.array([self.mean for i in range(n_pixels)]).flatten()
-        if inv_cov:
-            inv_covar_list = [self.inv_covar for m in range(n_pixels)]
-            inv_covar = block_diag(inv_covar_list, dtype=np.float32)
-            return x0, inv_covar
-        else:
-            covar_list = [self.covar for m in range(n_pixels)]
-            covar = block_diag(covar_list, dtype=np.float32)
-            return x0, covar
-
 class KafkaOutputMemory(object):
     """A very simple class to output the state."""
     def __init__(self, parameter_list):
@@ -147,55 +70,89 @@ class KafkaOutputMemory(object):
             solution[param] = x_analysis[ii::7]
         self.output[timestep] = solution
 
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
 
 if __name__ == "__main__":
-    
+
+    # Set up logging
+    Log = logging.getLogger(__name__+".kafka_test_x.py")
+
+
+    runname = 'Campinha_2017_Q0-1'  #Used in output directory as a unique identifier
+
+    # To run without propagation set propagator to None and set a
+    # prior in LinearKalman.
+    # If propagator is set to propagate_LAI_narrowbandSAIL then the
+    # prior in LinearKalman must be set to None because this propagator
+    # includes a prior
+    propagator = propagate_LAI_narrowbandSAIL
+
     parameter_list = ['n', 'cab', 'car', 'cbrown', 'cw', 'cm',
                       'lai', 'ala', 'bsoil', 'psoil']
-    
+
     start_time = "2017001"
-    
+
+    Log.info("propagator = {}".format(propagator))
+    Log.info("tile = {}".format(tile))
+    Log.info("start_time = {}".format(start_time))
+
+    path = "/tmp/kafkaout_{}".format(runname)
+    if not os.path.exists(path):
+        mkdir_p(path)
+
     #emulator_folder = "/home/ucfafyi/DATA/Multiply/emus/sail/"
     emulator_folder = "/home/glopez/Multiply/src/py36/emus/sail"
-    
+
     #data_folder = "/data/nemesis/S2_data/30/S/WJ/"
     data_folder = "/data/001_planet_sentinel_study/sentinel/30/S/WJ"
 
     state_mask = "./Barrax_pivots.tif"
-    
+
+
     s2_observations = Sentinel2Observations(data_folder,
-                                            emulator_folder, 
+                                            emulator_folder,
                                             state_mask)
 
     projection, geotransform = s2_observations.define_output()
 
     output = KafkaOutput(parameter_list, geotransform,
-                         projection, "/tmp/")
+                         projection, path)
 
+    # If using a separate prior then this is passed to LinearKalman
+    # Otherwise this is just used to set the starting state vector.
     the_prior = SAILPrior(parameter_list, state_mask)
 
     g = gdal.Open(state_mask)
     mask = g.ReadAsArray().astype(np.bool)
 
+    # prior = None when using propagate_LAI_narrowbandSAIL
     kf = LinearKalman(s2_observations, output, mask,
                       create_prosail_observation_operator,
                       parameter_list,
-                      state_propagation=None,
-                      prior=the_prior,
+                      state_propagation=propagator,
+                      prior=None,#the_prior,
                       linear=False)
 
     # Get starting state... We can request the prior object for this
     x_forecast, P_forecast_inv = the_prior.process_prior(None)
-    
+
     Q = np.zeros_like(x_forecast)
-    
+    Q[6::10] = 0.1
+
     kf.set_trajectory_model()
     kf.set_trajectory_uncertainty(Q)
-    
-    base = datetime(2017,7,3)
-    num_days = 10
-    time_grid = list((base + timedelta(days=x) 
+
+    # This determines the time grid of the retrieved state parameters
+    base = datetime(2017,1,1)
+    num_days = 366
+    time_grid = list((base + timedelta(days=x)
                      for x in range(0, num_days, 2)))
     kf.run(time_grid, x_forecast, None, P_forecast_inv,
            iter_obs_op=True)
-    

--- a/kafka_test_S2.py
+++ b/kafka_test_S2.py
@@ -4,7 +4,7 @@ import logging
 logging.basicConfig( 
     level=logging.getLevelName(logging.DEBUG), 
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    filename="the_log.log")
+    filename="logfiles/demo_Campinha_2017_Q0-05.log")
 import os
 from datetime import datetime, timedelta
 import numpy as np
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     Log = logging.getLogger(__name__+".kafka_test_x.py")
 
 
-    runname = 'Campinha_2017_Q0-1'  #Used in output directory as a unique identifier
+    runname = 'Campinha_2017_Q0-05'  #Used in output directory as a unique identifier
 
     # To run without propagation set propagator to None and set a
     # prior in LinearKalman.
@@ -98,11 +98,13 @@ if __name__ == "__main__":
                       'lai', 'ala', 'bsoil', 'psoil']
 
     start_time = "2017001"
+    time_grid_start = datetime(2017, 1, 1)
+    num_days = 366
 
     Log.info("propagator = {}".format(propagator))
     Log.info("start_time = {}".format(start_time))
 
-    path = "/tmp/kafkaout_{}".format(runname)
+    path = "/home/npounder/output/kafka/demo/S2/kafkaout_{}".format(runname)
     if not os.path.exists(path):
         mkdir_p(path)
 
@@ -144,15 +146,13 @@ if __name__ == "__main__":
 
     # Inflation amount for propagation
     Q = np.zeros_like(x_forecast)
-    Q[6::10] = 0.1
+    Q[6::10] = 0.05
 
     kf.set_trajectory_model()
     kf.set_trajectory_uncertainty(Q)
 
     # This determines the time grid of the retrieved state parameters
-    base = datetime(2017,1,1)
-    num_days = 366
-    time_grid = list((base + timedelta(days=x)
+    time_grid = list((time_grid_start + timedelta(days=x)
                      for x in range(0, num_days, 2)))
     kf.run(time_grid, x_forecast, None, P_forecast_inv,
            iter_obs_op=True)

--- a/kafka_test_S2.py
+++ b/kafka_test_S2.py
@@ -4,7 +4,7 @@ import logging
 logging.basicConfig( 
     level=logging.getLevelName(logging.DEBUG), 
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    filename="Campinha_noprop_2017.log")
+    filename="the_log.log")
 import os
 from datetime import datetime, timedelta
 import numpy as np
@@ -100,7 +100,6 @@ if __name__ == "__main__":
     start_time = "2017001"
 
     Log.info("propagator = {}".format(propagator))
-    Log.info("tile = {}".format(tile))
     Log.info("start_time = {}".format(start_time))
 
     path = "/tmp/kafkaout_{}".format(runname)
@@ -143,6 +142,7 @@ if __name__ == "__main__":
     # Get starting state... We can request the prior object for this
     x_forecast, P_forecast_inv = the_prior.process_prior(None)
 
+    # Inflation amount for propagation
     Q = np.zeros_like(x_forecast)
     Q[6::10] = 0.1
 


### PR DESCRIPTION
Hessian correction independent of model
Observation operator must be able to return gp hessian 
New propagator for narrow band SAIL for propagating only LAI
Model specific priors and propagators in their own files
Updated example scripts to run KaFKA